### PR TITLE
VICWOFOST.1.1.0

### DIFF
--- a/vic/plugins/routing/src/rout_basin_run.c
+++ b/vic/plugins/routing/src/rout_basin_run.c
@@ -140,7 +140,7 @@ rout_basin_run(size_t iCell)
 
     // Convolute current inflow
     convolve(dt_inflow, rout_steps_per_dt,
-             rout_con[iCell].runoff_uh, plugin_options.UH_LENGTH,
+             rout_con[iCell].inflow_uh, plugin_options.UH_LENGTH,
              convoluted);
     for (i = 0; i < rout_steps_per_dt + plugin_options.UH_LENGTH - 1; i++) {
         rout_var[iCell].dt_discharge[i] += convoluted[i];

--- a/vic/vic_run/include/vic_def.h
+++ b/vic/vic_run/include/vic_def.h
@@ -75,7 +75,7 @@
 #define MIN_SNOW_WETFRAC 0.01  /**< Minimum fraction of snow depth to be considered wet */
 
 /***** Define minimum and maximum values for model timesteps *****/
-#define MIN_SUBDAILY_STEPS_PER_DAY  4
+#define MIN_SUBDAILY_STEPS_PER_DAY  1
 #define MAX_SUBDAILY_STEPS_PER_DAY  1440
 
 #ifndef WET


### PR DESCRIPTION
1. Hotfix for routing bug (where the grid unit hydrograph was used for the river unit hydrograph)
2. Removed the subdaily forcing requirement